### PR TITLE
FOGL-9652 Cleanup unit tests allocations

### DIFF
--- a/tests/test_expression.cpp
+++ b/tests/test_expression.cpp
@@ -19,6 +19,7 @@ extern "C" {
 	PLUGIN_HANDLE plugin_init(ConfigCategory* config,
 			  OUTPUT_HANDLE *outHandle,
 			  OUTPUT_STREAM output);
+	void plugin_shutdown(PLUGIN_HANDLE handle);
 	int called = 0;
 
 	void Handler(void *handle, READINGSET *readings)
@@ -53,6 +54,8 @@ TEST(EXPRESSION, Addition)
 
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	readings->clear();
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 
@@ -86,4 +89,8 @@ TEST(EXPRESSION, Addition)
 			ASSERT_STREQ(outdp->getName().c_str(), "result");
 		}
 	}
+
+	delete outReadings;
+	delete config;
+	plugin_shutdown(handle);
 }


### PR DESCRIPTION
==2470010== 
==2470010== HEAP SUMMARY:
==2470010==     in use at exit: 0 bytes in 0 blocks
==2470010==   total heap usage: 168,397 allocs, 168,397 frees, 39,130,392 bytes allocated
==2470010== 
==2470010== All heap blocks were freed -- no leaks are possible
==2470010== 
==2470010== For lists of detected and suppressed errors, rerun with: -s
==2470010== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)